### PR TITLE
Update dough

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
         <dependency>
             <groupId>com.github.baked-libs.dough</groupId>
             <artifactId>dough-api</artifactId>
-            <version>a6519e666c</version>
+            <version>1108163a49</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Updates dough to no longer use deprecated code and improve updates from blob builds.